### PR TITLE
Handle Transpose input is channel_first for MoveForwardOptimizer

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -206,10 +206,16 @@ class LinkedNode(object):
             self.output[key] = name
 
     def get_input_by_idx(self, idx=0):
+        if self.origin is None:
+            assert idx == 0
+            return list(self.input.values())[0]
         onode_input_name = self.origin.input[idx]
         return self.input[onode_input_name]
 
     def get_output_by_idx(self, idx=0):
+        if self.origin is None:
+            assert idx == 0
+            return list(self.output.values())[0]
         onode_output_name = self.origin.output[idx]
         return self.output[onode_output_name]
 


### PR DESCRIPTION
Find a test failure for `test_channel_first_input` for python 3.5 and tf.keras win. It looks random, but the reason is because the `Transpose` input is a channel_first input, so it triggers MoveForwardSolution begin is a input, so it does not have origin.