### PR TITLE
Import FloatTensorType from datatypes

### DIFF
--- a/onnxconverter_common/topology.py
+++ b/onnxconverter_common/topology.py
@@ -9,7 +9,7 @@ import warnings
 from distutils.version import StrictVersion
 from onnx import helper
 from . import registration
-from .data_types import TensorType, Int64Type, FloatType, StringType
+from .data_types import TensorType, FloatTensorType, Int64Type, FloatType, StringType
 from .onnx_ex import OPSET_TO_IR_VERSION, DEFAULT_OPSET_NUMBER, make_model_ex, onnx_builtin_opset_version
 from .container import ModelComponentContainer
 from .optimizer import optimize_onnx


### PR DESCRIPTION
FloatTensorType is imported in test_SVMConverters.py in onnxmltools nightly build.