### PR TITLE
Skip MergeCommonSequenceOptimizer when node has initializers

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -1438,6 +1438,9 @@ class MergeCommonSequenceOptimizer(object):
             if count > 1:
                 return False
 
+        if len(node_0.initializers) > 0 or len(node_1.initializers) > 0:
+            return False
+
         for idx_ in range(len(node_0.precedence)):
             pred_0 = node_0.get_precedence_by_idx(idx_)
             pred_1 = node_1.get_precedence_by_idx(idx_)


### PR DESCRIPTION
One case is that we want to merge two Pad ops. Pad op should have two inputs, but `len(node_0.precedence)=1` because it generates `initializers` during optimization process. The original code does not compare initializers so it merges two Pad ops wrongly. So let's skip this case.