### PR TITLE
Pass succ.successor to MergeSolution rather than succ.successor[0]

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -779,7 +779,7 @@ class TransposeOptimizer(object):
                         else:
                             break
                     if succ.is_transpose:
-                        solution = MergeSolution(node.get_precedence_by_idx(0), node, succ, succ.successor[0])
+                        solution = MergeSolution(node.get_precedence_by_idx(0), node, succ, succ.successor)
                         return solution
 
                 last_switchable = node


### PR DESCRIPTION
One model pattern is Transpose -> Transpose -> (A, B), so it has two successors. 
MergeSolution gets triggered in TransposeOptimizer to remove the second Transpose. It need pass all B's successors rather than successor[0]. This PR is the fix.