### PR TITLE
Initialize container node_domain_version_pair_sets

### DIFF
--- a/onnxconverter_common/container.py
+++ b/onnxconverter_common/container.py
@@ -95,7 +95,7 @@ class ModelComponentContainer(ModelContainer):
         # ONNX nodes (type: NodeProto) used to define computation structure
         self.nodes = []
         # ONNX operators' domain-version pair set. They will be added into opset_import field in the final ONNX model.
-        self.node_domain_version_pair_sets = set()
+        self.node_domain_version_pair_sets = {('', target_opset)}
         # The targeted ONNX operator set (referred to as opset) that matches the ONNX version.
         self.target_opset = target_opset
         self.enable_optimizer = True

--- a/onnxconverter_common/onnx_fx.py
+++ b/onnxconverter_common/onnx_fx.py
@@ -254,11 +254,11 @@ class Graph:
         onnx.save_model(self.oxml, path)
 
     @staticmethod
-    def load(path, name=None, inputs=None, outputs=None):
+    def load(path_or_model, name=None, inputs=None, outputs=None):
         """
         Construct a Graph object by loading an ONNX model.
         """
-        oxml = onnx.load_model(path)
+        oxml = onnx.load_model(path_or_model) if isinstance(path_or_model, str) else path_or_model
         g = Graph(name or oxml.graph.name)
         g._bind(oxml, inputs=inputs, outputs=outputs)
         return g


### PR DESCRIPTION
If we just want to combine several models using Graph API, then it only add Identity node which op_version=1 by default. Since `node_domain_version_pair_sets=set()` at initialization, it will only be a ('', 1), then the generated onnx model is opset 1 always. This is wrong. So we want to initialize `node_domain_version_pair_sets`.