### PR TITLE
Add build_oxml to force build oxml

### DIFF
--- a/onnxconverter_common/onnx_fx.py
+++ b/onnxconverter_common/onnx_fx.py
@@ -83,6 +83,10 @@ class Graph:
     def name(self):
         return self._name
 
+    def build_oxml(self):
+        self._build_graph(self._onnxfunc, *self._onnxfunc_args, **self._onnxfunc_kwargs)
+        return self._oxml
+
     def _bind(self, oxml, inputs, outputs):
         ox_graph = oxml.graph
         initializer_set = {


### PR DESCRIPTION
If we just call `oxml`, it will skip building oxml if it exists, then it cannot reuse and fails `test_yolov3` case 2 after case 1 finish.