### PR TITLE
Remove Matmul from broadcast op

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -1075,7 +1075,7 @@ class MergeSqueezeUnsqueezeOptimizer(object):
 
 
 _broadcast_types = {'Add', 'And', 'Div', 'Equal', 'Greater', 'GreaterOrEqual', 'Less', 'LessOrEqual',
-                    'MatMul', 'Max', 'Mean', 'Min', 'Mod', 'Mul', 'Or', 'Pow', 'PRelu', 'Sub', 'Sum',
+                    'Max', 'Mean', 'Min', 'Mod', 'Mul', 'Or', 'Pow', 'PRelu', 'Sub', 'Sum',
                     'Where', 'Xor'}
 _transpose_pass_type_set = {'Pad', 'Squeeze', 'Unsqueeze', 'Slice'}
 _transpose_pass_type_set.update(_broadcast_types)

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -302,7 +302,7 @@ class OptimizerTestCase(unittest.TestCase):
     def test_onnx_models(self):
         model_names = ['mobile_segnet_no_opt.onnx', 'srgan_no_opt.onnx', 'test_model_0_no_opt.onnx',
                        'test_model_1_no_opt.onnx']
-        num_transpose_list = [2, 3, 11, 4]
+        num_transpose_list = [2, 3, 11, 5]
         dir_path = os.path.dirname(os.path.realpath(__file__))
         for idx_, model_name_ in enumerate(model_names):
             model_dir = dir_path + '/data/' + model_name_


### PR DESCRIPTION
Some keras2onnx tests fails, because when we pass `Matmul` op, we try to broadcast the initializer, but it seems the current broadcast does not work for `Matmul`.