### PR TITLE
Add Softsign activation function.

### DIFF
--- a/onnxconverter_common/onnx_ops.py
+++ b/onnxconverter_common/onnx_ops.py
@@ -851,7 +851,8 @@ def apply_sigmoid(scope, input_name, output_name, container, operator_name=None)
 
 
 def apply_softsign(scope, input_name, output_name, container, operator_name=None):
-    _apply_unary_operation(scope, 'Softsign', input_name, output_name, container, operator_name)
+    name = _create_name_or_use_existing_one(scope, 'Softsign', operator_name)
+    container.add_node('Softsign', input_name, output_name, name=name, op_version=1)
 
 
 # See alpha and gamma at https://github.com/keras-team/keras/blob/master/keras/activations.py#L80-L81

--- a/onnxconverter_common/onnx_ops.py
+++ b/onnxconverter_common/onnx_ops.py
@@ -851,7 +851,7 @@ def apply_sigmoid(scope, input_name, output_name, container, operator_name=None)
 
 
 def apply_softsign(scope, input_name, output_name, container, operator_name=None):
-    _apply_unary_operation(scope, 'SoftSign', input_name, output_name, container, operator_name)
+    _apply_unary_operation(scope, 'Softsign', input_name, output_name, container, operator_name)
 
 
 # See alpha and gamma at https://github.com/keras-team/keras/blob/master/keras/activations.py#L80-L81

--- a/onnxconverter_common/onnx_ops.py
+++ b/onnxconverter_common/onnx_ops.py
@@ -850,6 +850,10 @@ def apply_sigmoid(scope, input_name, output_name, container, operator_name=None)
     _apply_unary_operation(scope, 'Sigmoid', input_name, output_name, container, operator_name)
 
 
+def apply_softsign(scope, input_name, output_name, container, operator_name=None):
+    _apply_unary_operation(scope, 'SoftSign', input_name, output_name, container, operator_name)
+
+
 # See alpha and gamma at https://github.com/keras-team/keras/blob/master/keras/activations.py#L80-L81
 def apply_selu(scope, input_name, output_name, container, operator_name=None, alpha=1.673263, gamma=1.050701):
     _apply_unary_operation(scope, 'Selu', input_name, output_name, container, operator_name, alpha=alpha, gamma=gamma)

--- a/onnxconverter_common/oopb.py
+++ b/onnxconverter_common/oopb.py
@@ -352,6 +352,9 @@ class OnnxOperatorBuilder:
     def sigmoid(self, inputs, name=None, outputs=None):
         return self.apply_op(onnx_ops.apply_sigmoid, inputs, name, outputs)
 
+    def softsign(self, inputs, name=None, outputs=None):
+        return self.apply_op(onnx_ops.apply_softsign, inputs, name, outputs)
+
     def selu(self, inputs, name=None, outputs=None, alpha=1.673263, gamma=1.050701):
         return self.apply_op(onnx_ops.apply_selu, inputs, name, outputs, alpha=alpha, gamma=gamma)
 


### PR DESCRIPTION
This very minimal PR adds support for converting [softsign activations](https://www.tensorflow.org/api_docs/python/tf/nn/softsign) which are becoming popular in tensorflow and keras models. Fortunately, Onnx already has [a SoftSign node](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softsign) so this is pretty straightforward. I didn't see any explicit tests for other activations, but please let me know if one should be added.