### PR TITLE
Handle Split op in is_same_node_merge

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -1544,6 +1544,8 @@ class MergeCommonSequenceOptimizer(object):
             return False
         if node_0.origin.name == node_1.origin.name:
             return False
+        if len(node_0.output) > 1 or len(node_1.output) > 1:
+            return False
         no_merge_count = 0
         for node_suc_ in node_0.successor:
             if node_suc_.origin is None:


### PR DESCRIPTION
Optimization fails for keras-bert [model](https://github.com/CyberZHG/keras-bert/) conversion, because we want to merge two Split op in `MergeCommonSequence`. Note that Split op has multiple outputs, so we want to skip this case.