### PR TITLE
Fix next.precedence range(1, 5) case in ConvBatchNormOptimizer

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -855,7 +855,7 @@ class ConvBatchNormOptimizer(object):
                     return None
                 else:
                     for idx_ in range(1, 5):
-                        if len(next.precedence[idx_].tensors) == 0:
+                        if len(next.get_precedence_by_idx(idx_).tensors) == 0:
                             return None
 
                 solution = ConvBatchNormSolution(node.get_precedence_by_idx(0), node, next, next.successor)


### PR DESCRIPTION
Converting a SRGAN model [here](https://github.com/krasserm/super-resolution), find Conv+BatchNorm does not merge, and find that `conv` is `next.precedence[4]`, so we need use `get_precedence_by_idx()` to get the precedence.