### PR TITLE
Pass Max/Min for PushTransposeSolution

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -1023,7 +1023,7 @@ def _update_broadcast_from_initializers(node, init_pred_value, cur_perm, init_id
 _nchw_input_node_type = ['Conv', 'ConvTranspose', 'BatchNormalization', 'Mul']
 _activation_node_type = ['Elu', 'HardSigmoid', 'LeakyRelu', 'Relu', 'Selu', 'Sigmoid', 'Softmax', 'Softplus',
                          'Softsign', 'Tanh']
-_broadcast_flip_whitelist = {'Transpose', 'Conv', 'BatchNormalization', 'Resize', 'Reshape', 'Add', 'Mul'}
+_broadcast_flip_whitelist = {'Transpose', 'Conv', 'BatchNormalization', 'Resize', 'Reshape', 'Add', 'Mul', 'Max', 'Min'}
 _broadcast_flip_whitelist.update(_activation_node_type)
 
 
@@ -1261,7 +1261,12 @@ class PushTransposeSolution(Solution):
 
         for node_pair_ in node_transpose_no_pass:
             if len(node_pair_[0].precedence) > 1:
-                return None, False
+                pred_count = 0
+                for pred_ in node_pair_[0].precedence:
+                    if pred_.origin is not None:
+                        pred_count += 1
+                if pred_count > 1:
+                    return None, False
 
         for node_pair_ in node_transpose_pass:
             (node, prev) = node_pair_


### PR DESCRIPTION
Converting a deep-speaker model [here](https://github.com/philipperemy/deep-speaker). There is a pattern Conv->Max->Min, so we need add Max/Min to `_broadcast_flip_whitelist`. For one case, when we `PushTransposeSolution`, it stops at a `Reshape` node and skip optimization. For this case, I relax the logic to allow "one input" case. 