### PR TITLE
Fix PushTransposeSolution for a node_transpose_no_pass case

### DIFF
--- a/onnxconverter_common/optimizer.py
+++ b/onnxconverter_common/optimizer.py
@@ -1266,6 +1266,8 @@ class PushTransposeSolution(Solution):
                 for pred_ in node_pair_[0].precedence:
                     if pred_.origin is not None:
                         pred_count += 1
+                    elif len(pred_.tensors) == 0:  # not an initializer
+                        pred_count += 1
                 if pred_count > 1:
                     return None, False
 


### PR DESCRIPTION
The PR [139](https://github.com/microsoft/onnxconverter-common/pull/139) has a bug which makes `test_pix2pix` fail in keras2onnx nightly build. The pix2pix model has a `Concat` node for `node_transpose_no_pass`, and this `Concat` node has one input which is model input, this is not an initializer. In this case, we should skip PushTranspose optimization. We can only do optimization when all other inputs of `node_transpose_no_pass` are initializers.