### PR TITLE
Support >2GB ONNX models for fp16 conversion

### DIFF
--- a/onnxconverter_common/__init__.py
+++ b/onnxconverter_common/__init__.py
@@ -26,5 +26,5 @@ from .tree_ensemble import *  # noqa F403
 from .utils import *  # noqa F403
 from .case_insensitive_dict import *  # noqa F403
 from .metadata_props import add_metadata_props, set_denotation
-from .float16 import convert_tensor_float_to_float16, convert_float_to_float16
+from .float16 import convert_tensor_float_to_float16, convert_float_to_float16, convert_float_to_float16_model_path
 from .optimizer import optimize_onnx, optimize_onnx_graph, optimize_onnx_model

--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -84,6 +84,8 @@ def convert_float_to_float16(model, min_positive_val=1e-7, max_finite_val=1e4,
     Convert tensor float type in the ONNX ModelProto input to tensor float16.
 
     :param model: ONNX ModelProto object
+    :param disable_shape_infer: Type/shape information is needed for conversion to work.
+                                Set to True only if the model already has type/shape information for all tensors.
     :return: converted ONNX ModelProto object
 
     Examples:
@@ -103,13 +105,12 @@ def convert_float_to_float16(model, min_positive_val=1e-7, max_finite_val=1e4,
 
     '''
     func_infer_shape = None
-    if not disable_shape_infer:
-        if onnx.__version__ >= '1.2':
-            try:
-                from onnx.shape_inference import infer_shapes
-                func_infer_shape = infer_shapes
-            finally:
-                pass
+    if not disable_shape_infer and onnx.__version__ >= '1.2':
+        try:
+            from onnx.shape_inference import infer_shapes
+            func_infer_shape = infer_shapes
+        finally:
+            pass
 
     if not isinstance(model, onnx_proto.ModelProto):
         raise ValueError('Expected model type is an ONNX ModelProto but got %s' % type(model))
@@ -274,9 +275,8 @@ def convert_float_to_float16_model_path(model_path, min_positive_val=1e-7, max_f
     ::
         #Convert to ONNX ModelProto object and save model binary file:
         from onnxmltools.utils.float16_converter import convert_float_to_float16_model_path
-        from onnxmltools.utils import save_model
         new_onnx_model = convert_float_to_float16_model_path('model.onnx')
-        save_model(new_onnx_model, 'new_model.onnx')
+        onnx.save(new_onnx_model, 'new_model.onnx')
     '''
 
     disable_shape_infer = False


### PR DESCRIPTION
The original infer_shapes function will fail on model size>2GB, because of protobuf size limitation. 
Error message:
![image](https://user-images.githubusercontent.com/6299908/104072645-9af12e00-51c0-11eb-9dee-75d0517edfb2.png)

For >2GB model shape infer, it should use a new function introduced in onnx 1.7.0, infer_shapes_path. However, this new function requires the input and output to be model path, instead of ModelProto object. 

Here is my previous issue report to ONNX: https://github.com/onnx/onnx/issues/3046
Here is the doc for infer_shapes_path: https://github.com/onnx/onnx/blob/master/docs/PythonAPIOverview.md#shape-inference-a-large-onnx-model-2gb