### PR TITLE
Remove instanceNormalization op from DEFAULT_OP_BLOCK_LIST

### DIFF
--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -82,7 +82,7 @@ DEFAULT_OP_BLOCK_LIST = ['ArrayFeatureExtractor', 'Binarizer', 'CastMap', 'Categ
                          'FeatureVectorizer', 'Imputer', 'LabelEncoder', 'LinearClassifier', 'LinearRegressor',
                          'Normalizer', 'OneHotEncoder', 'SVMClassifier', 'SVMRegressor', 'Scaler',
                          'TreeEnsembleClassifier', 'TreeEnsembleRegressor', 'ZipMap', 'NonMaxSuppression', 'TopK',
-                         'RoiAlign', 'Resize', 'Range', 'CumSum', 'Min', 'Max', 'Upsample', 'InstanceNormalization']
+                         'RoiAlign', 'Resize', 'Range', 'CumSum', 'Min', 'Max', 'Upsample']
 
 
 def convert_float_to_float16(model, min_positive_val=1e-7, max_finite_val=1e4,


### PR DESCRIPTION
This PR is to remove InstanceNormalization op from DEFAULT_OP_BLOCK_LIST. 

The background is:

- 3 months ago, I found InstanceNormalization was unable to work on fp16. It would generate below error:

```
File "/usr/local/lib/python3.6/dist-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 124, in run
return self._sess.run(output_names, input_feed, run_options)
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running InstanceNormalization node. Name:'InstanceNormalization_31' Status Message: CUDNN error executing cudnnBatchNormalizationForwardTraining( CudnnHandle(), CUDNN_BATCHNORM_SPATIAL, &one, &zero, data_desc, x_data, data_desc, y_data, stats_desc, unused_scale.get(), unused_bias.get(), 1.0f, mean.get(), variance.get(), CUDNN_BN_MIN_EPSILON, nullptr, nullptr)
```
And, @TomWildenhain-Microsoft helped create this PR to block InstanceNormalization to convert fp16: https://github.com/microsoft/onnxconverter-common/pull/197

- Meanwhile, I also asked ORT team's help to investigate and fix InstanceNormalization op issue on fp16. The fix was done recently (Nov. 29, 2021) by @hariharans29 in this PR: https://github.com/microsoft/onnxruntime/pull/9879

So, InstanceNormalization is no needed to be blocked any more. And this PR is to remove InstanceNormalization op from DEFAULT_OP_BLOCK_LIST. 
