### PR TITLE
upgrade versioning API

### DIFF
--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -6,7 +6,7 @@
 import itertools
 import numpy as np
 import onnx
-from verlib import NormalizedVersion as V
+from distutils.version import LooseVersion as V
 from onnx import helper, numpy_helper
 from onnx import onnx_pb as onnx_proto
 

--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -6,7 +6,7 @@
 import itertools
 import numpy as np
 import onnx
-from distutils.version import StrictVersion
+from verlib import NormalizedVersion as V
 from onnx import helper, numpy_helper
 from onnx import onnx_pb as onnx_proto
 
@@ -114,7 +114,7 @@ def convert_float_to_float16(model, min_positive_val=1e-7, max_finite_val=1e4,
 
     '''
     func_infer_shape = None
-    if not disable_shape_infer and StrictVersion(onnx.__version__) >= StrictVersion('1.2'):
+    if not disable_shape_infer and V(onnx.__version__) >= V('1.2'):
         try:
             from onnx.shape_inference import infer_shapes
             func_infer_shape = infer_shapes
@@ -293,7 +293,7 @@ def convert_float_to_float16_model_path(model_path, min_positive_val=1e-7, max_f
     '''
 
     disable_shape_infer = False
-    if StrictVersion(onnx.__version__) >= StrictVersion('1.8'):
+    if V(onnx.__version__) >= V('1.8'):
         try:
             # infer_shapes_path can be applied to all model sizes
             from onnx.shape_inference import infer_shapes_path

--- a/onnxconverter_common/topology.py
+++ b/onnxconverter_common/topology.py
@@ -7,7 +7,7 @@
 import re
 import onnx
 import warnings
-from distutils.version import StrictVersion
+from verlib import NormalizedVersion as V
 from onnx import helper
 from .registration import get_converter, get_shape_calculator
 from .data_types import TensorType, Int64Type, FloatType, StringType
@@ -691,7 +691,7 @@ def convert_topology(topology, model_name, doc_string, target_opset, targeted_on
         Possible values include '1.1.2', '1.2', and so on.
     :return: a ONNX ModelProto
     '''
-    if targeted_onnx is not None and StrictVersion(targeted_onnx) != StrictVersion(onnx.__version__):
+    if targeted_onnx is not None and V(targeted_onnx) != V(onnx.__version__):
         warnings.warn(
             'targeted_onnx is deprecated, please specify target_opset for the target model.\n' +
             '*** ONNX version conflict found. The installed version is %s while the targeted version is %s' % (

--- a/onnxconverter_common/topology.py
+++ b/onnxconverter_common/topology.py
@@ -7,7 +7,7 @@
 import re
 import onnx
 import warnings
-from verlib import NormalizedVersion as V
+from distutils.version import LooseVersion as V
 from onnx import helper
 from .registration import get_converter, get_shape_calculator
 from .data_types import TensorType, Int64Type, FloatType, StringType

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 protobuf
 onnx
-verlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 protobuf
 onnx
+verlib

--- a/tests/test_auto_mixed_precision_model_path.py
+++ b/tests/test_auto_mixed_precision_model_path.py
@@ -3,7 +3,7 @@ import numpy as np
 import onnxruntime as _ort
 import onnx
 import os
-from distutils.version import StrictVersion
+from verlib import NormalizedVersion as V
 from onnxconverter_common.onnx_fx import Graph
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported
 from onnxconverter_common.auto_mixed_precision_model_path import auto_convert_mixed_precision_model_path
@@ -18,7 +18,7 @@ Graph.inference_runtime = _ort_inference
 Graph.opset = 9
 onnx_function = Graph.trace
 
-@unittest.skipIf(StrictVersion(onnx.__version__) <= StrictVersion('1.8.0'), "test for ONNX 1.8 and above")
+@unittest.skipIf(V(onnx.__version__) <= V('1.8.0'), "test for ONNX 1.8 and above")
 @unittest.skipIf(get_maximum_opset_supported() < 9, "tests designed for ONNX opset 9 and greater")
 @unittest.skipIf(not hasattr(onnx, "shape_inference"), "shape inference is required")
 class AutoFloat16Test(unittest.TestCase):

--- a/tests/test_auto_mixed_precision_model_path.py
+++ b/tests/test_auto_mixed_precision_model_path.py
@@ -3,7 +3,7 @@ import numpy as np
 import onnxruntime as _ort
 import onnx
 import os
-from verlib import NormalizedVersion as V
+from distutils.version import LooseVersion as V
 from onnxconverter_common.onnx_fx import Graph
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported
 from onnxconverter_common.auto_mixed_precision_model_path import auto_convert_mixed_precision_model_path

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,7 +1,4 @@
-import os
-import onnx
 import unittest
-from distutils.version import StrictVersion
 from onnx import onnx_pb as onnx_proto
 from onnxconverter_common.data_types import (
     BooleanTensorType,

--- a/tests/test_float16.py
+++ b/tests/test_float16.py
@@ -5,7 +5,7 @@ import numpy as np
 import onnx
 import onnxruntime as _ort
 import onnxmltools
-from verlib import NormalizedVersion as V
+from distutils.version import LooseVersion as V
 from onnxconverter_common.onnx_fx import Graph, OnnxOperatorBuilderX
 from onnxconverter_common.onnx_fx import GraphFunctionType as _Ty
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported

--- a/tests/test_float16.py
+++ b/tests/test_float16.py
@@ -5,7 +5,7 @@ import numpy as np
 import onnx
 import onnxruntime as _ort
 import onnxmltools
-from distutils.version import StrictVersion
+from verlib import NormalizedVersion as V
 from onnxconverter_common.onnx_fx import Graph, OnnxOperatorBuilderX
 from onnxconverter_common.onnx_fx import GraphFunctionType as _Ty
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported
@@ -22,7 +22,7 @@ Graph.inference_runtime = _ort_inference
 Graph.opset = 9
 onnx_function = Graph.trace
 
-@unittest.skipIf(StrictVersion(onnx.__version__) <= StrictVersion('1.8.0'), "test for ONNX 1.8 and above")
+@unittest.skipIf(V(onnx.__version__) <= V('1.8.0'), "test for ONNX 1.8 and above")
 @unittest.skipIf(get_maximum_opset_supported() < 9, "tests designed for ONNX opset 9 and greater")
 class ONNXFloat16Test(unittest.TestCase):
     def test_float16(self):

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,7 +1,7 @@
 import os
 import onnx
 import unittest
-from distutils.version import StrictVersion
+from verlib import NormalizedVersion as V
 from onnxconverter_common.data_types import FloatTensorType
 from onnxconverter_common import set_denotation
 
@@ -19,7 +19,7 @@ class TestTypes(unittest.TestCase):
         o = onx.sequence_type
         assert str(o) == ""
 
-    @unittest.skipIf(StrictVersion(onnx.__version__) < StrictVersion('1.2.1'),
+    @unittest.skipIf(V(onnx.__version__) < V('1.2.1'),
                      "not supported in this ONNX version")
     def test_set_denotation(self):
         this = os.path.dirname(__file__)

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,7 +1,7 @@
 import os
 import onnx
 import unittest
-from verlib import NormalizedVersion as V
+from distutils.version import LooseVersion as V
 from onnxconverter_common.data_types import FloatTensorType
 from onnxconverter_common import set_denotation
 

--- a/tests/test_onnxfx.py
+++ b/tests/test_onnxfx.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 import onnxruntime as _ort
-from verlib import NormalizedVersion as V
+from distutils.version import LooseVersion as V
 from onnxconverter_common.onnx_fx import Graph, OnnxOperatorBuilderX
 from onnxconverter_common.onnx_fx import GraphFunctionType as _Ty
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported

--- a/tests/test_onnxfx.py
+++ b/tests/test_onnxfx.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 import onnxruntime as _ort
-from distutils.version import StrictVersion
+from verlib import NormalizedVersion as V
 from onnxconverter_common.onnx_fx import Graph, OnnxOperatorBuilderX
 from onnxconverter_common.onnx_fx import GraphFunctionType as _Ty
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported
@@ -57,7 +57,7 @@ class ONNXFunctionTest(unittest.TestCase):
         self.assertEqual(
             loop_test(np.array([16], dtype=np.int64))[2][4], 3.0)
 
-    @unittest.skipIf(StrictVersion(_ort.__version__.split('-')[0]) < StrictVersion("1.4.0"),
+    @unittest.skipIf(V(_ort.__version__.split('-')[0]) < V("1.4.0"),
                      "onnxruntime fixed the issue in matmul since 1.4.0")
     def test_matmul_opt(self):
         @onnx_function(outputs=['z'],


### PR DESCRIPTION
Signed-off-by: xiaowuhu <xiaowuhu@microsoft.com>

due to the StrictVersion will be deprecated and it cannot recognize version such as "1.12.0rc5", so changed to use verlib.NormalizedVersion, according to this spec: https://peps.python.org/pep-0386/