### PR TITLE
shorten CI pipeline

### DIFF
--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -13,10 +13,6 @@ jobs:
     vmImage: 'Ubuntu-18.04'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.6.0
-
       Python381:
         python.version: '3.8'
         ONNX_PATH: onnx==1.7.0

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -13,10 +13,6 @@ jobs:
     vmImage: 'windows-latest'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.6.0
-
       Python381:
         python.version: '3.8'
         ONNX_PATH: onnx==1.7.0


### PR DESCRIPTION
Signed-off-by: xiaowuhu <xiaowuhu@microsoft.com>

remove testing for onnx 1.6 and 1.7 because they were born 3 years ago.