### PR TITLE
Add RandomUinformLike into convert2fp16 blocking list and update version to 1.12.2

### DIFF
--- a/onnxconverter_common/__init__.py
+++ b/onnxconverter_common/__init__.py
@@ -8,7 +8,7 @@ The entry point to onnxconverter-common.
 This framework performs optimization for ONNX models and
 includes common utilities for ONNX converters.
 """
-__version__ = "1.12.1"
+__version__ = "1.12.2"
 __author__ = "Microsoft"
 __producer__ = "OnnxMLTools"
 __producer_version__ = __version__

--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -81,7 +81,7 @@ def make_value_info_from_tensor(tensor):
 
 DEFAULT_OP_BLOCK_LIST = ['ArrayFeatureExtractor', 'Binarizer', 'CastMap', 'CategoryMapper', 'DictVectorizer',
                          'FeatureVectorizer', 'Imputer', 'LabelEncoder', 'LinearClassifier', 'LinearRegressor',
-                         'Normalizer', 'OneHotEncoder', 'SVMClassifier', 'SVMRegressor', 'Scaler',
+                         'Normalizer', 'OneHotEncoder', 'RandomUniformLike', 'SVMClassifier', 'SVMRegressor', 'Scaler',
                          'TreeEnsembleClassifier', 'TreeEnsembleRegressor', 'ZipMap', 'NonMaxSuppression', 'TopK',
                          'RoiAlign', 'Resize', 'Range', 'CumSum', 'Min', 'Max', 'Upsample']
 


### PR DESCRIPTION
RandomUinformLike operator has a dtype attribute, default is float32, but when convert to fp16 model, the converter cannot automatically change the dtype attribute from float32 to float16, so we add this operator into block list.