### PR TITLE
add packaging into requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 protobuf
 onnx
+packaging


### PR DESCRIPTION
Signed-off-by: xiaowuhu <xiaowuhu@microsoft.com>

missing dependency for 'packaging' in requirement.txt.