### PR TITLE
Add additional arguments to model_path function call

### DIFF
--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -299,7 +299,8 @@ def convert_float_to_float16(model, min_positive_val=1e-7, max_finite_val=1e4,
     return model
 
 
-def convert_float_to_float16_model_path(model_path, min_positive_val=1e-7, max_finite_val=1e4, keep_io_types=False):
+def convert_float_to_float16_model_path(model_path, min_positive_val=1e-7, max_finite_val=1e4, keep_io_types=False,
+                             op_block_list=None, node_block_list=None):
     '''
     Convert tensor float type in the ONNX Model to tensor float16.
     *It is to fix an issue that infer_shapes func cannot be used to infer >2GB models.
@@ -331,4 +332,5 @@ def convert_float_to_float16_model_path(model_path, min_positive_val=1e-7, max_f
             pass
     if not disable_shape_infer:
         model = onnx.load(model_path)
-    return convert_float_to_float16(model, min_positive_val, max_finite_val, keep_io_types, disable_shape_infer)
+    return convert_float_to_float16(model, min_positive_val, max_finite_val, keep_io_types, disable_shape_infer,
+                op_block_list=op_block_list, node_block_list=node_block_list)


### PR DESCRIPTION
This forwards two arguments from the `convert_float_to_float16_model_path` wrapper function to `convert_float_to_float16_model_path` to complete the API.

This functionality is needed to enable usage of the `model_path` API in groqflow.