### PR TITLE
relax protobuf restriction

### DIFF
--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -54,7 +54,7 @@ jobs:
       python -m pip install --upgrade pip
       conda config --set always_yes yes --set changeps1 no
       conda install -c conda-forge numpy
-      pip install protobuf==3.20.2
+      pip install 'protobuf>=3.20.2'
       pip install pytest
     displayName: 'Install dependencies'
 

--- a/.azure-pipelines/nightly-CI.yml
+++ b/.azure-pipelines/nightly-CI.yml
@@ -50,7 +50,7 @@ jobs:
       pip uninstall -y onnxruntime
       pip install --index-url https://test.pypi.org/simple/ ort-nightly
       pip install $(ONNX_PATH)
-      pip install protobuf==3.20.2
+      pip install 'protobuf>=3.20.2'
       pip install pytest
       pip install -e .
     displayName: 'Install dependencies'

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -44,7 +44,7 @@ jobs:
       pip install onnxruntime
       pip install onnxmltools
       pip install %ONNX_PATH%
-      pip install protobuf==3.20.2
+      pip install 'protobuf>=3.20.2'
       pip install pytest
       pip install -e .
     displayName: 'Install dependencies'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["numpy", "onnx", "packaging", "protobuf==3.20.2"]
+dependencies = ["numpy", "onnx", "packaging", "protobuf>=3.20.2"]
 
 [tool.setuptools.dynamic]
 version = {attr = "onnxconverter_common.__version__"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 onnx
 packaging
-protobuf==3.20.2
+protobuf>=3.20.2


### PR DESCRIPTION
fixes https://github.com/microsoft/onnxconverter-common/issues/265

`onnx` itself specifics `>=3.20.2` - https://github.com/onnx/onnx/blob/main/requirements.txt#L2C17-L2C17
`onnxruntime` has no restriction - https://github.com/microsoft/onnxruntime/blob/main/requirements.txt.in#L5