### PR TITLE
Fix onnx.mapping reference for onnx 1.19

### DIFF
--- a/onnxconverter_common/_opt_const_folding.py
+++ b/onnxconverter_common/_opt_const_folding.py
@@ -4,7 +4,7 @@
 ###############################################################################
 
 import numpy as np
-from onnx import numpy_helper, mapping, helper
+from onnx import numpy_helper, helper
 
 
 class OnnxGraphContext:
@@ -74,9 +74,9 @@ class OnnxGraphContext:
         return [np.add(inputs[0], inputs[1])]
 
     def _OnCast(self, node, inputs):
-        np_dtype = mapping.TENSOR_TYPE_TO_NP_TYPE[
+        np_dtype = helper.tensor_dtype_to_np_dtype(
             OnnxGraphContext.get_attribute(node, "to")
-        ]
+        )
         casted = inputs[0].astype(np_dtype)
         return [casted]
 

--- a/onnxconverter_common/auto_mixed_precision.py
+++ b/onnxconverter_common/auto_mixed_precision.py
@@ -29,7 +29,7 @@ Example usage:
 import onnx
 import numpy as np
 from onnxconverter_common import float16
-from onnx import helper, mapping
+from onnx import helper
 import copy
 
 
@@ -131,7 +131,7 @@ def add_missing_dtypes_using_ort(model, feed_dict, outputs_per_iter=100):
         outs = outputs[i : i + outputs_per_iter]
         vals = get_tensor_values_using_ort(model, feed_dict, outs)
         for out, val in zip(outs, vals):
-            out_to_dtype[out] = mapping.NP_TYPE_TO_TENSOR_TYPE[val.dtype]
+            out_to_dtype[out] = helper.np_dtype_to_tensor_dtype(val.dtype)
         i += outputs_per_iter
     for out, dtype in out_to_dtype.items():
         model.graph.value_info.append(

--- a/onnxconverter_common/onnx_ops.py
+++ b/onnxconverter_common/onnx_ops.py
@@ -8,8 +8,8 @@
 # `container` argument. Notice that those function behaviors are defined in a way very similar to ONNX-1.2.
 
 import numpy as np
+import onnx
 from onnx import onnx_pb as onnx_proto
-from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
 
 
 def _create_name_or_use_existing_one(scope, op_type, name):
@@ -325,7 +325,7 @@ def apply_clip(
                 else:
                     min = np.array(min)
                     container.add_initializer(
-                        min_name, NP_TYPE_TO_TENSOR_TYPE[min.dtype], [], [min[0]]
+                        min_name, onnx.helper.np_dtype_to_tensor_dtype(min.dtype), [], [min[0]]
                     )
                 min = min_name
             if isinstance(min, str):
@@ -360,7 +360,7 @@ def apply_clip(
                 else:
                     max = np.array(max)
                     container.add_initializer(
-                        max_name, NP_TYPE_TO_TENSOR_TYPE[max.dtype], [], [max[0]]
+                        max_name, onnx.helper.np_dtype_to_tensor_dtype(max.dtype), [], [max[0]]
                     )
                 max = max_name
             if isinstance(max, str):

--- a/onnxconverter_common/oopb.py
+++ b/onnxconverter_common/oopb.py
@@ -5,7 +5,6 @@
 ###############################################################################
 import numpy as np
 from onnx import onnx_pb as onnx_proto, helper
-from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
 from . import onnx_ops
 
 

--- a/onnxconverter_common/topology.py
+++ b/onnxconverter_common/topology.py
@@ -12,11 +12,9 @@ from onnx import helper
 from .registration import get_converter, get_shape_calculator
 from .data_types import TensorType, Int64Type, FloatType, StringType
 from .onnx_ex import (
-    OPSET_TO_IR_VERSION,
-    DEFAULT_OPSET_NUMBER,
     make_model_ex,
     get_maximum_opset_supported,
-)  # noqa
+)
 from .container import ModelComponentContainer
 from .optimizer import optimize_onnx
 from .interface import OperatorBase, ScopeBase


### PR DESCRIPTION
ONNX 1.19 removed the deprecated onnx.mapping module. This PR fixes the usages.

Fix https://github.com/onnx/onnx/issues/7257