### PR TITLE
Fix regression of inconsistent `Cast` node in 1.15.

### DIFF
--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -10,6 +10,7 @@ import packaging.version as pv
 import warnings
 from onnx import helper, numpy_helper
 from onnx import onnx_pb as onnx_proto
+from typing import List
 
 
 FLOAT32 = 1
@@ -230,6 +231,7 @@ def convert_float_to_float16(
             process_graph_input(
                 curr_graph, is_top_level, keep_io_types, global_input_name_dict
             )
+            process_cast32_node(curr_graph, op_block_list, node_block_list)
             value_info_block_list = process_tensor_in_node(
                 curr_graph,
                 op_block_list,
@@ -430,6 +432,25 @@ def insert_cast16_after_node(
                 )
                 node.output[i] = cast_input_name
                 break
+
+
+# Replace all Cast<float32> (e.g. from int or for type erasure) by Cast<float16>.
+def process_cast32_node(
+    graph: onnx_proto.GraphProto,
+    op_block_list: List[str],
+    node_block_list: List[str],
+):
+    if "Cast" in op_block_list:
+        return
+    for node in graph.node:
+        if node.op_type == "Cast" and node.name not in node_block_list:
+            for attr in node.attribute:
+                if (
+                    attr.name == "to"
+                    and attr.type == onnx_proto.AttributeProto.AttributeType.INT
+                    and attr.i == onnx_proto.TensorProto.FLOAT
+                ):
+                    attr.i = onnx_proto.TensorProto.FLOAT16
 
 
 # Process tensor data in attribute of the node


### PR DESCRIPTION
The new converter tags the output of `Cast<float32>` to FP16 in value_info without changing itself to `Cast<float16>`.
- https://github.com/microsoft/onnxconverter-common/pull/291

Ort reports mismatch between tagged/inferred types when loading.

In 1.14, the previous implementation handled this in:
- https://github.com/microsoft/onnxconverter-common/blob/8d2f85f0a7039a0b0defd6c7509cb905914a4d2f/onnxconverter_common/float16.py#L229-L233