### PR TITLE
Fix the mismatch between the Cast node’s output type and its “to” attribute.

### DIFF
--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -187,6 +187,14 @@ def initial_checking(model, disable_shape_infer):
     if func_infer_shape is not None:
         model = func_infer_shape(model)
 
+    # If a TensorProto appears in both value_info and output, a type-mismatch error may occur,
+    # especially when keep_io_types is true.
+    # onnx.shape_inference.infer_shapes may add a TensorProto to value_info even when one with
+    # the same name already exists in output.
+    for output in model.graph.output:
+        if output in model.graph.value_info:
+            model.graph.value_info.remove(output)
+
     is_fp16_ready_flag = check_if_fp16_ready(model.graph)
 
     return model, func_infer_shape, is_fp16_ready_flag

--- a/onnxconverter_common/float16.py
+++ b/onnxconverter_common/float16.py
@@ -262,6 +262,7 @@ def convert_float_to_float16(
 
     sort_topology(model.graph)
     remove_unnecessary_cast_node(model.graph)
+    update_cast_attribute(model.graph)
 
     return model
 
@@ -794,6 +795,34 @@ def remove_unnecessary_cast_node(graph_proto: onnx_proto.GraphProto):
     for cast_node_pair in remove_candidate:
         graph_proto.node.remove(cast_node_pair[0])
         graph_proto.node.remove(cast_node_pair[1])
+
+
+# Update Cast attribulte "to" so that it matches the dtype of its output
+def update_cast_attribute(graph_proto):
+    assert isinstance(graph_proto, onnx_proto.GraphProto)
+
+    # make a map from name to value info
+    value_info_dict = {}
+    for value_info in itertools.chain(
+        graph_proto.output, graph_proto.input, graph_proto.value_info
+    ):
+        value_info_dict[value_info.name] = value_info
+
+    # update Cast attribute "to"
+    for node in graph_proto.node:
+        if node.op_type == "Cast":
+            for attr in node.attribute:
+                if attr.name == "to":
+                    attr.i = value_info_dict[node.output[0]].type.tensor_type.elem_type
+
+    # recursively update for subgraphs
+    for node in graph_proto.node:
+        for attr in node.attribute:
+            if isinstance(attr.g, onnx_proto.GraphProto) and len(attr.g.node) > 0:
+                update_cast_attribute(attr.g)
+            for g in attr.graphs:
+                if isinstance(g, onnx_proto.GraphProto):
+                    update_cast_attribute(g)
 
 
 # Check if the model is already converted to float16


### PR DESCRIPTION
When I convert ONNX models that contain Cast nodes whose "to" attribute is set to 1 (float32), the fp16-converted model produces the following error:

```
Type Error: Type (tensor(float16)) of output arg (/Cast_output_0) of node (/Cast) does not match expected type (tensor(float)).
```

This happens because the output type of the Cast node is converted to fp16, but the "to" attribute is not updated accordingly.
To fix this, I added an update_cast_attribute step so that the Cast node’s output type matches its "to" attribute.